### PR TITLE
README.md changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,26 +25,17 @@ To allow authentication, you first need to register your application at Azure Ap
 
 1. Login at [Azure Portal (App Registrations)](https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade). Personal accounts may receive an authentication notification that can be ignored.
 
-2. Create a new App Registration. Give it a name. In Supported account types, choose "Accounts in any organizational directory and personal Microsoft accounts (e.g. Skype, Xbox, Outlook.com)", if you are using a personal account. SHOULD THEY SELECT SOMETHING ELSE IF THEY'RE USING A BUSINESS ACCOUNT? Click Register.
+2. Create a new App Registration. Give it a name. In Supported account types, choose "Accounts in any organizational directory and personal Microsoft accounts (e.g. Skype, Xbox, Outlook.com)" for greatest freedom of login account. Choose other options if you are confident it will cover the type of account you are using to login.  Click Register.
 
-3. Click Add a Redirect URI.  Click Add a platform.  Select Web. Set redirect URI according to one of the following two methods to authenticate your Home Assistant instance for access to your Office 365 account(s): 
+3. Click Add a Redirect URI. Click Add a platform. Select Web. Set redirect URI to: `https://login.microsoftonline.com/common/oauth2/nativeclient`, leave the other fields blank and click Configure.
 
-   * Primary (Default) Authentication Method - Use if...WHY SHOULD WE BE USING THIS INSTEAD OF THE ALT METHOD?
-      - Set `https://login.microsoftonline.com/common/oauth2/nativeclient`
-      - Leave the other fields blank
-      - Click Configure
-   * Alternate Authentication Method - Why again? Requires internet access to HA, please see the [Authentication](#authentication) section.
-      - Set `https://<your_home_assistant_url_or_local_ip>/api/o365` (Nabu Casa users should use `https://<NabuCasaBaseAddress>/api/o365` instead)
-      - Leave the other fields blank
-      - Click Configure
+   An alternate method of authentication is available which requires internet access to your HA instance if preferred. The alternate method is simpler to use when authenticating, but is more complex to setup correctly. See [Authentication](#authentication) section for more details.
 
-   _**NOTE:** As of version 3.2.0, the primary (default) and alternate authentication methods have essentially reversed. The primary (default) method now DOES NOT require direct access to your HA instance from the internet while the alternate method DOES require direct access. If you previously did NOT set alt_auth_flow or had it set to False, please set alt_auth_method to True and remove alt_auth_flow from your config. This will only be necessary upon re-authentication._
+   _**NOTE:** As of version 3.2.0, the primary (default) and alternate authentication methods have essentially reversed. The primary (default) method now DOES NOT require direct access to your HA instance from the internet while the alternate method DOES require direct access. If you previously did NOT set 'alt_auth_flow' or had it set to False, please set 'alt_auth_method' to True and remove 'alt_auth_flow' from your config. This will only be necessary upon re-authentication._
 
-   If you are using Multi-factor Authentication (MFA), you may find you also need to add `https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize` to your redirect URIs. DOES THIS APPLY TO BOTH METHODS? EITHER WAY, LET'S MOVE IT UP AS A SECOND BULLET UNDER ONE OR BOTH METHODS ABOVE.
+4. From the Overview page, copy the Application (client) ID.
 
-5. From the Overview page, temporarily copy the Application (client) ID.
-
-5. Under "Certificates & secrets", generate a new client secret. Set the expiration as desired.  This appears to be limited to 2 years. Temporarily copy the Value of the client secret now. It will be hidden later on.  If you lose track of the secret, return here to generate a new one.
+5. Under "Certificates & secrets", generate a new client secret. Set the expiration as desired.  This appears to be limited to 2 years. Copy the Value of the client secret now. It will be hidden later on.  If you lose track of the secret, return here to generate a new one.
 
 6. Under "API Permissions" click Add a permission, then Microsoft Graph, then Delegated permission, and add the following permissions:
    * offline_access - *Maintain access to data you have given it access to*
@@ -69,17 +60,18 @@ To allow authentication, you first need to register your application at Azure Ap
 1. Install this integration:
     * Recommended - Home Assistant Community Store (HACS) or
     * Manually - Copy [these files](https://github.com/RogerSelwyn/O365-HomeAssistant/tree/master/custom_components/o365) to custom_components/o365/.
-1. Add o365 configuration to configuration.yaml using the [Configuration example](#configuration-example) below.
-1. Restart your Home Assistant instance.
+2. Add o365 configuration to configuration.yaml using the [Configuration example](#configuration-example) below.
+3. Restart your Home Assistant instance.
    **Note:** if Home Assistant give the error "module not found", try restarting home assistant once more.
-1. [Authenticate](#authentication) to establish the link between this integration and the Azure app
+4. A persistent notification will be shown in the Notifications panel of your HA instance. Follow the instructions on this notification (or see [Authenticate](#authentication)) to establish the link between this integration and the Azure app
     * A persistent token will be created in the hidden directory config/.O365-token-cache
     * The o365_calendars_<account_name>.yaml (or o365_calendars.yaml for secondary configuration method) will be created under the config directory
-1. [Configure Calendars](#calendar-configuration)
+5. [Configure Calendars](#calendar-configuration)
+6. Restart your Home Assistant instance.
 
 ## Configuration examples
 
-### Primary configuration format - Preferred because it provides improved security and allows for multiple accounts.
+### Primary configuration format (from v3.x.x) - Preferred because it provides improved security and allows for multiple accounts.
 ```yaml
 # Example configuration.yaml entry for multiple accounts
 o365:
@@ -200,7 +192,7 @@ Key | Type | Required | Description
 `name` | `string` | `True` | The name of the sensor.
 
 ## Authentication
-   _**NOTE:** As of version 3.2.0, the primary (default) and alternate authentication methods have essentially reversed. The primary (default) method now DOES NOT require direct access to your HA instance from the internet while the alternate method DOES require direct access. If you previously did NOT set alt_auth_flow or had it set to False, please set alt_auth_method to True and remove alt_auth_flow from your config. This will only be necessary upon re-authentication._
+   _**NOTE:** As of version 3.2.0, the primary (default) and alternate authentication methods have essentially reversed. The primary (default) method now DOES NOT require direct access to your HA instance from the internet while the alternate method DOES require direct access. If you previously did NOT set 'alt_auth_flow' or had it set to False, please set 'alt_auth_method' to True and remove 'alt_auth_flow' from your config. This will only be necessary upon re-authentication._
 
 ### Primary (default) authentication method
 After setting up configuration.yaml and restarting Home Assistant, a persistent notification will be created.
@@ -219,6 +211,9 @@ After setting up configuration.yaml with the key set to _True_ and restarting Ho
 2. Click the "Link O365 account" link.
 3. Login on the Microsoft page; when prompted, authorize the app you created
 4. Close the window when the message "Success! This window can be closed" appears.
+
+### Multi-Factor Authentication (MFA)
+If you are using Multi-factor Authentication (MFA), you may find you also need to add `https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize` to your redirect URIs.
 
 ## Calendar configuration
 The integration uses an external o365_calendars_<account_name>.yaml file (or o365_calendars.yaml for the secondary configuration format).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This integration enables:
 1. Getting and creating calendar events from O365.
-2. Getting emails from your inbox.
+2. Getting emails from your inbox using one of two available sensors (e-mail and query).
 3. Sending emails via the notify.o365_email service.
 4. Getting presence from Teams (not for personal accounts)
 5. Getting the latest chat message from Teams (not for personal accounts)
@@ -25,19 +25,19 @@ To allow authentication, you first need to register your application at Azure Ap
 
 1. Login at [Azure Portal (App Registrations)](https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade). Personal accounts may receive an authentication notification that can be ignored.
 
-2. Create a new App Registration. Give it a name. In Supported account types, choose "Accounts in any organizational directory and personal Microsoft accounts (e.g. Skype, Xbox, Outlook.com)" for greatest freedom of login account. Choose other options if you are confident it will cover the type of account you are using to login.  Click Register.
+1. Create a new App Registration. Give it a name. In Supported account types, choose "Accounts in any organizational directory and personal Microsoft accounts (e.g. Skype, Xbox, Outlook.com)" for greatest freedom of login account. Choose other options if you are confident it will cover the type of account you are using to login.  Click Register.
 
-3. Click Add a Redirect URI. Click Add a platform. Select Web. Set redirect URI to: `https://login.microsoftonline.com/common/oauth2/nativeclient`, leave the other fields blank and click Configure.
+1. Click Add a Redirect URI. Click Add a platform. Select Web. Set redirect URI to: `https://login.microsoftonline.com/common/oauth2/nativeclient`, leave the other fields blank and click Configure.
 
-   An alternate method of authentication is available which requires internet access to your HA instance if preferred. The alternate method is simpler to use when authenticating, but is more complex to setup correctly. See [Authentication](#authentication) section for more details.
+   An alternate method of authentication is available which requires internet access to your HA instance if preferred. The alternate method is simpler to use when authenticating, but is more complex to setup correctly. See [Authentication](#authentication) section for more details. I AGREE WITH THESE CHANGES TO KEEP THE FLOW, BUT I STILL THINK IT WOULD BE HELPFUL TO ADD MORE DETAILS ABOUT THE PROS/CONS OF EACH METHOD...MAYBE IN THE AUTHENTICATION SECTION AS THE PREVIOUS SENTENCE IMPLIES?
 
    _**NOTE:** As of version 3.2.0, the primary (default) and alternate authentication methods have essentially reversed. The primary (default) method now DOES NOT require direct access to your HA instance from the internet while the alternate method DOES require direct access. If you previously did NOT set 'alt_auth_flow' or had it set to False, please set 'alt_auth_method' to True and remove 'alt_auth_flow' from your config. This will only be necessary upon re-authentication._
 
-4. From the Overview page, copy the Application (client) ID.
+1. From the Overview page, copy the Application (client) ID.
 
-5. Under "Certificates & secrets", generate a new client secret. Set the expiration as desired.  This appears to be limited to 2 years. Copy the Value of the client secret now. It will be hidden later on.  If you lose track of the secret, return here to generate a new one.
+1. Under "Certificates & secrets", generate a new client secret. Set the expiration as desired.  This appears to be limited to 2 years. Copy the Value of the client secret now. It will be hidden later on.  If you lose track of the secret, return here to generate a new one.
 
-6. Under "API Permissions" click Add a permission, then Microsoft Graph, then Delegated permission, and add the following permissions:
+1. Under "API Permissions" click Add a permission, then Microsoft Graph, then Delegated permission, and add the following permissions:
    * offline_access - *Maintain access to data you have given it access to*
    * Calendars.Read - *Read user calendars*
    * Users.Read - *Sign in and read user profile*
@@ -60,18 +60,18 @@ To allow authentication, you first need to register your application at Azure Ap
 1. Install this integration:
     * Recommended - Home Assistant Community Store (HACS) or
     * Manually - Copy [these files](https://github.com/RogerSelwyn/O365-HomeAssistant/tree/master/custom_components/o365) to custom_components/o365/.
-2. Add o365 configuration to configuration.yaml using the [Configuration example](#configuration-example) below.
-3. Restart your Home Assistant instance.
-   **Note:** if Home Assistant give the error "module not found", try restarting home assistant once more.
-4. A persistent notification will be shown in the Notifications panel of your HA instance. Follow the instructions on this notification (or see [Authenticate](#authentication)) to establish the link between this integration and the Azure app
+1. Add o365 configuration to configuration.yaml using the [Configuration example](#configuration-example) below.
+1. Restart your Home Assistant instance.
+   **Note:** if Home Assistant gives the error "module not found", try restarting home assistant once more.
+1. A persistent notification will be shown in the Notifications panel of your HA instance. Follow the instructions on this notification (or see [Authentication](#authentication)) to establish the link between this integration and the Azure app
     * A persistent token will be created in the hidden directory config/.O365-token-cache
     * The o365_calendars_<account_name>.yaml (or o365_calendars.yaml for secondary configuration method) will be created under the config directory
-5. [Configure Calendars](#calendar-configuration)
-6. Restart your Home Assistant instance.
+1. [Configure Calendars](#calendar-configuration)
+1. Restart your Home Assistant instance.
 
 ## Configuration examples
 
-### Primary configuration format (from v3.x.x) - Preferred because it provides improved security and allows for multiple accounts.
+### Primary configuration format (as of v3.x.x) - Preferred because it provides improved security and allows for multiple accounts.
 ```yaml
 # Example configuration.yaml entry for multiple accounts
 o365:
@@ -158,7 +158,7 @@ Key | Type | Required | Description
 `query_sensors` | `list<query_sensors>` | `False` | List of query_sensor config entries
 `status_sensors` | `list<status_sensors>` | `False` | List of status_sensor config entries. *Not for use on personal accounts*
 
-#### email_sensors
+#### email_sensors WHY WOULD ONE USE THIS SENSOR IN LIEU OF THE MORE CAPABLE QUERY SENSOR (I.E. WHAT DOES THIS SENSOR PROVIDE)?
 Key | Type | Required | Description
 -- | -- | -- | --
 `name` | `string` | `True` | The name of the sensor.
@@ -299,7 +299,7 @@ Respond to an event in the specified calendar - All paremeters are shown in the 
 ### o365.scan_for_calendars
 Scan for new calendars and add to o365_calendars.yaml - No parameters.
 
-## Calendar Sensor layout
+## Calendar Sensor layout I DID NOT NOTICE THIS PREVIOUSLY SINCE IT'S TOWARD THE BOTTOM, BUT IS THIS CALENDAR SENSOR ALREADY CREATED, OR IS THIS MEANT TO HELP THE USER GET STARTED WITH CREATING A TEMPLATE SENSOR (WHICH DOES NOT YET EXIST UPON INSTALLATION)? EITHER WAY, SHOULD IT BE PULLED UP IN THE DOCUMENTATION ABOVE THE SERVICE CALLS...MAYBE RIGHT BELOW THE EMAIL AND QUERY SENSOR SECTION?
 The status of the calendar sensor indicates (on/off) whether there is an event on at the current time. The `message`, `all_day`, `start_time`, `end_time`, `location`, `description` and `offset_reached` attributes provide details of the current of next event. A non all-day event is favoured over all_day events.
 
 The `data` attribute provides an array of events for the period defined by the `start_offset` and `end_offset` in o365_calendars_<account_name>.yaml. Individual array elements can be accessed using the notation `{{ states.calendar.calendar_<account_name>.attributes.data[0...n] }}`

--- a/README.md
+++ b/README.md
@@ -25,19 +25,19 @@ To allow authentication, you first need to register your application at Azure Ap
 
 1. Login at [Azure Portal (App Registrations)](https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade). Personal accounts may receive an authentication notification that can be ignored.
 
-1. Create a new App Registration. Give it a name. In Supported account types, choose "Accounts in any organizational directory and personal Microsoft accounts (e.g. Skype, Xbox, Outlook.com)" for greatest freedom of login account. Choose other options if you are confident it will cover the type of account you are using to login.  Click Register.
+2. Create a new App Registration. Give it a name. In Supported account types, choose "Accounts in any organizational directory and personal Microsoft accounts (e.g. Skype, Xbox, Outlook.com)" for greatest freedom of login account. Choose other options if you are confident it will cover the type of account you are using to login.  Click Register.
 
-1. Click Add a Redirect URI. Click Add a platform. Select Web. Set redirect URI to: `https://login.microsoftonline.com/common/oauth2/nativeclient`, leave the other fields blank and click Configure.
+3. Click Add a Redirect URI. Click Add a platform. Select Web. Set redirect URI to: `https://login.microsoftonline.com/common/oauth2/nativeclient`, leave the other fields blank and click Configure.
 
    An alternate method of authentication is available which requires internet access to your HA instance if preferred. The alternate method is simpler to use when authenticating, but is more complex to setup correctly. See [Authentication](#authentication) section for more details. I AGREE WITH THESE CHANGES TO KEEP THE FLOW, BUT I STILL THINK IT WOULD BE HELPFUL TO ADD MORE DETAILS ABOUT THE PROS/CONS OF EACH METHOD...MAYBE IN THE AUTHENTICATION SECTION AS THE PREVIOUS SENTENCE IMPLIES?
 
    _**NOTE:** As of version 3.2.0, the primary (default) and alternate authentication methods have essentially reversed. The primary (default) method now DOES NOT require direct access to your HA instance from the internet while the alternate method DOES require direct access. If you previously did NOT set 'alt_auth_flow' or had it set to False, please set 'alt_auth_method' to True and remove 'alt_auth_flow' from your config. This will only be necessary upon re-authentication._
 
-1. From the Overview page, copy the Application (client) ID.
+4. From the Overview page, copy the Application (client) ID.
 
-1. Under "Certificates & secrets", generate a new client secret. Set the expiration as desired.  This appears to be limited to 2 years. Copy the Value of the client secret now. It will be hidden later on.  If you lose track of the secret, return here to generate a new one.
+5. Under "Certificates & secrets", generate a new client secret. Set the expiration as desired.  This appears to be limited to 2 years. Copy the Value of the client secret now. It will be hidden later on.  If you lose track of the secret, return here to generate a new one.
 
-1. Under "API Permissions" click Add a permission, then Microsoft Graph, then Delegated permission, and add the following permissions:
+6. Under "API Permissions" click Add a permission, then Microsoft Graph, then Delegated permission, and add the following permissions:
    * offline_access - *Maintain access to data you have given it access to*
    * Calendars.Read - *Read user calendars*
    * Users.Read - *Sign in and read user profile*
@@ -60,14 +60,14 @@ To allow authentication, you first need to register your application at Azure Ap
 1. Install this integration:
     * Recommended - Home Assistant Community Store (HACS) or
     * Manually - Copy [these files](https://github.com/RogerSelwyn/O365-HomeAssistant/tree/master/custom_components/o365) to custom_components/o365/.
-1. Add o365 configuration to configuration.yaml using the [Configuration example](#configuration-example) below.
-1. Restart your Home Assistant instance.
+2. Add o365 configuration to configuration.yaml using the [Configuration example](#configuration-example) below.
+3. Restart your Home Assistant instance.
    **Note:** if Home Assistant gives the error "module not found", try restarting home assistant once more.
-1. A persistent notification will be shown in the Notifications panel of your HA instance. Follow the instructions on this notification (or see [Authentication](#authentication)) to establish the link between this integration and the Azure app
+4. A persistent notification will be shown in the Notifications panel of your HA instance. Follow the instructions on this notification (or see [Authentication](#authentication)) to establish the link between this integration and the Azure app
     * A persistent token will be created in the hidden directory config/.O365-token-cache
     * The o365_calendars_<account_name>.yaml (or o365_calendars.yaml for secondary configuration method) will be created under the config directory
-1. [Configure Calendars](#calendar-configuration)
-1. Restart your Home Assistant instance.
+5. [Configure Calendars](#calendar-configuration)
+6. Restart your Home Assistant instance.
 
 ## Configuration examples
 
@@ -158,7 +158,7 @@ Key | Type | Required | Description
 `query_sensors` | `list<query_sensors>` | `False` | List of query_sensor config entries
 `status_sensors` | `list<status_sensors>` | `False` | List of status_sensor config entries. *Not for use on personal accounts*
 
-#### email_sensors WHY WOULD ONE USE THIS SENSOR IN LIEU OF THE MORE CAPABLE QUERY SENSOR (I.E. WHAT DOES THIS SENSOR PROVIDE)?
+#### email_sensors [RWJS] Again not created by me, I'm not sure the email_sensor brings extra benefit and I have rationalised the code in support of the two methods. But with 1k+ users I can't remove the email_sensor.
 Key | Type | Required | Description
 -- | -- | -- | --
 `name` | `string` | `True` | The name of the sensor.
@@ -192,9 +192,17 @@ Key | Type | Required | Description
 `name` | `string` | `True` | The name of the sensor.
 
 ## Authentication
-   _**NOTE:** As of version 3.2.0, the primary (default) and alternate authentication methods have essentially reversed. The primary (default) method now DOES NOT require direct access to your HA instance from the internet while the alternate method DOES require direct access. If you previously did NOT set 'alt_auth_flow' or had it set to False, please set 'alt_auth_method' to True and remove 'alt_auth_flow' from your config. This will only be necessary upon re-authentication._
+ _**NOTE:** As of version 3.2.0, the primary (default) and alternate authentication methods have essentially reversed. The primary (default) method now DOES NOT require direct access to your HA instance from the internet while the alternate method DOES require direct access. If you previously did NOT set 'alt_auth_flow' or had it set to False, please set 'alt_auth_method' to True and remove 'alt_auth_flow' from your config. This will only be necessary upon re-authentication._
+
+The Primary method of authentication is the simplest to configure and requires no access from the internet to your HA instance, therefore is the most secure method. It has slightly more steps to follow when actually do the authentication.
+
+The alternate method is more complex to setup, since the Azure App that is created in the prerequisites section must be configured to enable authentication from your HA instance whether located in your home network or utilising a cloud service such as Nabu Casa. The actual authentication is slightly simpler with fewer steps.
+
+During setup, the difference in configuration between each methid is the value of the redirect uri on your Azure App. The authetication steps for each method are shown below.
 
 ### Primary (default) authentication method
+This requires *alt_auth_methos* to be set to *False* or be not present and the redirect uri in your Azure app set to `https://login.microsoftonline.com/common/oauth2/nativeclient`.
+
 After setting up configuration.yaml and restarting Home Assistant, a persistent notification will be created.
 1. Click on this notification.
 2. Click the "Link O365 account" link.
@@ -299,7 +307,7 @@ Respond to an event in the specified calendar - All paremeters are shown in the 
 ### o365.scan_for_calendars
 Scan for new calendars and add to o365_calendars.yaml - No parameters.
 
-## Calendar Sensor layout I DID NOT NOTICE THIS PREVIOUSLY SINCE IT'S TOWARD THE BOTTOM, BUT IS THIS CALENDAR SENSOR ALREADY CREATED, OR IS THIS MEANT TO HELP THE USER GET STARTED WITH CREATING A TEMPLATE SENSOR (WHICH DOES NOT YET EXIST UPON INSTALLATION)? EITHER WAY, SHOULD IT BE PULLED UP IN THE DOCUMENTATION ABOVE THE SERVICE CALLS...MAYBE RIGHT BELOW THE EMAIL AND QUERY SENSOR SECTION?
+## Calendar Sensor layout - [RWJS] - It's just to help people understand what the calendar shows because there are many who seem unable to interpret what they are seeing.
 The status of the calendar sensor indicates (on/off) whether there is an event on at the current time. The `message`, `all_day`, `start_time`, `end_time`, `location`, `description` and `offset_reached` attributes provide details of the current of next event. A non all-day event is favoured over all_day events.
 
 The `data` attribute provides an array of events for the period defined by the `start_offset` and `end_offset` in o365_calendars_<account_name>.yaml. Individual array elements can be accessed using the notation `{{ states.calendar.calendar_<account_name>.attributes.data[0...n] }}`

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This integration enables:
 1. Getting and creating calendar events from O365.
-2. Getting emails from your inbox using one of two available sensors (e-mail and query).
+2. Getting emails from your inbox using one of two available sensor templates (e-mail and query).
 3. Sending emails via the notify.o365_email service.
 4. Getting presence from Teams (not for personal accounts)
 5. Getting the latest chat message from Teams (not for personal accounts)
@@ -29,7 +29,7 @@ To allow authentication, you first need to register your application at Azure Ap
 
 3. Click Add a Redirect URI. Click Add a platform. Select Web. Set redirect URI to: `https://login.microsoftonline.com/common/oauth2/nativeclient`, leave the other fields blank and click Configure.
 
-   An alternate method of authentication is available which requires internet access to your HA instance if preferred. The alternate method is simpler to use when authenticating, but is more complex to setup correctly. See [Authentication](#authentication) section for more details. I AGREE WITH THESE CHANGES TO KEEP THE FLOW, BUT I STILL THINK IT WOULD BE HELPFUL TO ADD MORE DETAILS ABOUT THE PROS/CONS OF EACH METHOD...MAYBE IN THE AUTHENTICATION SECTION AS THE PREVIOUS SENTENCE IMPLIES?
+   An alternate method of authentication is available which requires internet access to your HA instance if preferred. The alternate method is simpler to use when authenticating, but is more complex to setup correctly. See [Authentication](#authentication) section for more details.
 
    _**NOTE:** As of version 3.2.0, the primary (default) and alternate authentication methods have essentially reversed. The primary (default) method now DOES NOT require direct access to your HA instance from the internet while the alternate method DOES require direct access. If you previously did NOT set 'alt_auth_flow' or had it set to False, please set 'alt_auth_method' to True and remove 'alt_auth_flow' from your config. This will only be necessary upon re-authentication._
 
@@ -158,7 +158,7 @@ Key | Type | Required | Description
 `query_sensors` | `list<query_sensors>` | `False` | List of query_sensor config entries
 `status_sensors` | `list<status_sensors>` | `False` | List of status_sensor config entries. *Not for use on personal accounts*
 
-#### email_sensors [RWJS] Again not created by me, I'm not sure the email_sensor brings extra benefit and I have rationalised the code in support of the two methods. But with 1k+ users I can't remove the email_sensor.
+#### email_sensors
 Key | Type | Required | Description
 -- | -- | -- | --
 `name` | `string` | `True` | The name of the sensor.
@@ -194,14 +194,14 @@ Key | Type | Required | Description
 ## Authentication
  _**NOTE:** As of version 3.2.0, the primary (default) and alternate authentication methods have essentially reversed. The primary (default) method now DOES NOT require direct access to your HA instance from the internet while the alternate method DOES require direct access. If you previously did NOT set 'alt_auth_flow' or had it set to False, please set 'alt_auth_method' to True and remove 'alt_auth_flow' from your config. This will only be necessary upon re-authentication._
 
-The Primary method of authentication is the simplest to configure and requires no access from the internet to your HA instance, therefore is the most secure method. It has slightly more steps to follow when actually do the authentication.
+The Primary method of authentication is the simplest to configure and requires no access from the internet to your HA instance, therefore is the most secure method. It has slightly more steps to follow when authenticating.
 
 The alternate method is more complex to setup, since the Azure App that is created in the prerequisites section must be configured to enable authentication from your HA instance whether located in your home network or utilising a cloud service such as Nabu Casa. The actual authentication is slightly simpler with fewer steps.
 
-During setup, the difference in configuration between each methid is the value of the redirect uri on your Azure App. The authetication steps for each method are shown below.
+During setup, the difference in configuration between each methid is the value of the redirect URI on your Azure App. The authentication steps for each method are shown below.
 
 ### Primary (default) authentication method
-This requires *alt_auth_methos* to be set to *False* or be not present and the redirect uri in your Azure app set to `https://login.microsoftonline.com/common/oauth2/nativeclient`.
+This requires *alt_auth_method* to be set to *False* or be not present and the redirect URI in your Azure app set to `https://login.microsoftonline.com/common/oauth2/nativeclient`.
 
 After setting up configuration.yaml and restarting Home Assistant, a persistent notification will be created.
 1. Click on this notification.
@@ -212,7 +212,7 @@ After setting up configuration.yaml and restarting Home Assistant, a persistent 
 6. Click Submit.
 
 ### Alternate authentication method
-This requires the *alt_auth_method* to be set to *True* and the redirect uri in your Azure app set to `https://<your_home_assistant_url_or_local_ip>/api/o365` (Nabu Casa users should use `https://<NabuCasaBaseAddress>/api/o365` instead).
+This requires the *alt_auth_method* to be set to *True* and the redirect URI in your Azure app set to `https://<your_home_assistant_url_or_local_ip>/api/o365` (Nabu Casa users should use `https://<NabuCasaBaseAddress>/api/o365` instead).
 
 After setting up configuration.yaml with the key set to _True_ and restarting Home Assistant a persistent notification will be created.
 1. Click on this notification.
@@ -307,7 +307,7 @@ Respond to an event in the specified calendar - All paremeters are shown in the 
 ### o365.scan_for_calendars
 Scan for new calendars and add to o365_calendars.yaml - No parameters.
 
-## Calendar Sensor layout - [RWJS] - It's just to help people understand what the calendar shows because there are many who seem unable to interpret what they are seeing.
+## Calendar Sensor layout
 The status of the calendar sensor indicates (on/off) whether there is an event on at the current time. The `message`, `all_day`, `start_time`, `end_time`, `location`, `description` and `offset_reached` attributes provide details of the current of next event. A non all-day event is favoured over all_day events.
 
 The `data` attribute provides an array of events for the period defined by the `start_offset` and `end_offset` in o365_calendars_<account_name>.yaml. Individual array elements can be accessed using the notation `{{ states.calendar.calendar_<account_name>.attributes.data[0...n] }}`
@@ -320,12 +320,12 @@ The `data` attribute provides an array of events for the period defined by the `
 * **Application {x} is not configured as a multi-tenant application.**
   * In your azure app go to Manifest, find the key "signInAudience", change its value to "AzureADandPersonalMicrosoftAccount"
 * **Platform error sensor.office365calendar - No module named '{x}'**
-  * This is a known home assistant issue, all that's needed to fix this should be another restart of your home assistant server. If this does not work, please try installing the component in this order:
+  * This is a known home assistant issue, all that's needed to fix this should be another restart of your home assistant server. If this does not work, please try installing the component in this order:  
 
 
-    1\. Install the component.
-    2\. Restart home assistant.
-    3\. Then add the sensor to your configuration.yaml
-    4\. Restart home assistant again.
+      1. Install the component.
+      2. Restart Home Assistant.
+      3. Add the sensor to your configuration.yaml
+      4. Restart Home Assistant again.
 
-**_Please note that any changes made to your Azure app settings takes a few minutes to propagate. Please wait around 5 minutes between changes to your settings and any auth attemps from Home Assistant_**
+**_Please note that any changes made to your Azure app settings takes a few minutes to propagate. Please wait around 5 minutes between changes to your settings and any auth attempts from Home Assistant._**

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ To allow authentication, you first need to register your application at Azure Ap
     * Manually - Copy [these files](https://github.com/RogerSelwyn/O365-HomeAssistant/tree/master/custom_components/o365) to custom_components/o365/.
 2. Add o365 configuration to configuration.yaml using the [Configuration example](#configuration-example) below.
 3. Restart your Home Assistant instance.
-   **Note:** if Home Assistant gives the error "module not found", try restarting home assistant once more.
+   **Note:** if Home Assistant gives the error "module not found", try restarting Home Assistant once more.
 4. A persistent notification will be shown in the Notifications panel of your HA instance. Follow the instructions on this notification (or see [Authentication](#authentication)) to establish the link between this integration and the Azure app
     * A persistent token will be created in the hidden directory config/.O365-token-cache
     * The o365_calendars_<account_name>.yaml (or o365_calendars.yaml for secondary configuration method) will be created under the config directory
@@ -320,7 +320,7 @@ The `data` attribute provides an array of events for the period defined by the `
 * **Application {x} is not configured as a multi-tenant application.**
   * In your azure app go to Manifest, find the key "signInAudience", change its value to "AzureADandPersonalMicrosoftAccount"
 * **Platform error sensor.office365calendar - No module named '{x}'**
-  * This is a known home assistant issue, all that's needed to fix this should be another restart of your home assistant server. If this does not work, please try installing the component in this order:
+  * This is a known Home Assistant issue, all that's needed to fix this should be another restart of your Home Assistant server. If this does not work, please try installing the component in this order:
 
 
       1. Install the component.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This integration enables:
 1. Getting and creating calendar events from O365.
-2. Getting emails from your inbox using one of two available sensor templates (e-mail and query).
+2. Getting emails from your inbox using one of two available sensor types (e-mail and query).
 3. Sending emails via the notify.o365_email service.
 4. Getting presence from Teams (not for personal accounts)
 5. Getting the latest chat message from Teams (not for personal accounts)
@@ -320,7 +320,7 @@ The `data` attribute provides an array of events for the period defined by the `
 * **Application {x} is not configured as a multi-tenant application.**
   * In your azure app go to Manifest, find the key "signInAudience", change its value to "AzureADandPersonalMicrosoftAccount"
 * **Platform error sensor.office365calendar - No module named '{x}'**
-  * This is a known home assistant issue, all that's needed to fix this should be another restart of your home assistant server. If this does not work, please try installing the component in this order:  
+  * This is a known home assistant issue, all that's needed to fix this should be another restart of your home assistant server. If this does not work, please try installing the component in this order:
 
 
       1. Install the component.

--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ o365:
           has_attachment: True
           max_items: 2
           is_unread: True
-          status_sensors: # Cannot be used for personal accounts
-            - name: "User Teams Status"
-          chat_sensors: # Cannot be used for personal accounts
-            - name: "User Chat"
+      status_sensors: # Cannot be used for personal accounts
+        - name: "User Teams Status"
+      chat_sensors: # Cannot be used for personal accounts
+        - name: "User Chat"
     - account_name: Account2
       client_secret: "xx.xxxxxxxxxxxxxxxxxxxxxxxxxxxx"
       client_id: "xxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx"
@@ -123,10 +123,10 @@ o365:
       has_attachment: True
       max_items: 2
       is_unread: True
-      status_sensors: # Cannot be used for personal accounts
-        - name: "User Teams Status"
-      chat_sensors: # Cannot be used for personal accounts
-        - name: "User Chat"
+  status_sensors: # Cannot be used for personal accounts
+    - name: "User Teams Status"
+  chat_sensors: # Cannot be used for personal accounts
+    - name: "User Chat"
 ```
 
 ### Configuration variables


### PR DESCRIPTION
@RogerSelwyn, As I tried to re-configure for 3.2.0, I got a little confused by the auth verbiage and why I would want to use either one, so I set out to make sense of it and modify the README in the process. I've embedded questions to you in ALL CAPS in a few spots. Can you please carefully review my proposed changes and unknowns to provide feedback?

I changed the verbiage to consistently use "method(s)" when referring to authentication and "format(s)" for configuration.

Also, why would one use an email_sensor instead of a query_sensor which has more options?