### PR TITLE
Improve service validation and remove deprecated calendar_id

### DIFF
--- a/custom_components/o365/calendar.py
+++ b/custom_components/o365/calendar.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from datetime import date, datetime, timedelta
 from operator import attrgetter, itemgetter
 
+import voluptuous as vol
 from homeassistant.components.calendar import (
     CalendarEntity,
     CalendarEvent,
@@ -367,12 +368,11 @@ class O365CalendarEntity(CalendarEntity):
             filename=build_token_filename(config, config.get(CONF_CONFIG_TYPE)),
         )
         if not validate_minimum_permission(PERM_MINIMUM_CALENDAR_WRITE, permissions):
-            _LOGGER.error(
-                "Not authorisied to %s calendar event - requires permission: %s",
-                error_message,
-                PERM_CALENDARS_READWRITE,
+            raise vol.Invalid(
+                f"Not authorisied to {PERM_CALENDARS_READWRITE} calendar event "
+                + f"- requires permission: {error_message}"
             )
-            return False
+
         return True
 
 
@@ -611,7 +611,7 @@ class CalendarServices:
 
 
 def _group_calendar_log(entity_id):
-    _LOGGER.error(
-        "O365 Python does not have capability to update/respond to group calendar events: %s",
-        entity_id,
+    raise vol.Invalid(
+        "O365 Python does not have capability "
+        + f"to update/respond to group calendar events: {entity_id}"
     )

--- a/custom_components/o365/schema.py
+++ b/custom_components/o365/schema.py
@@ -18,7 +18,6 @@ from .const import (
     ATTR_ATTACHMENTS,
     ATTR_ATTENDEES,
     ATTR_BODY,
-    ATTR_CALENDAR_ID,
     ATTR_CATEGORIES,
     ATTR_EMAIL,
     ATTR_END,
@@ -164,16 +163,13 @@ NOTIFY_BASE_SCHEMA = vol.Schema(
     }
 )
 
-CALENDAR_SERVICE_RESPOND_SCHEMA = vol.Schema(
-    {
-        vol.Optional(ATTR_ENTITY_ID): cv.string,
-        vol.Required(ATTR_EVENT_ID): cv.string,
-        vol.Required(ATTR_CALENDAR_ID): cv.string,
-        vol.Optional(ATTR_RESPONSE, None): cv.enum(EventResponse),
-        vol.Optional(ATTR_SEND_RESPONSE, True): bool,
-        vol.Optional(ATTR_MESSAGE, None): cv.string,
-    }
-)
+CALENDAR_SERVICE_RESPOND_SCHEMA = {
+    vol.Required(ATTR_ENTITY_ID): cv.string,
+    vol.Required(ATTR_EVENT_ID): cv.string,
+    vol.Required(ATTR_RESPONSE, None): cv.enum(EventResponse),
+    vol.Optional(ATTR_SEND_RESPONSE, True): bool,
+    vol.Optional(ATTR_MESSAGE, None): cv.string,
+}
 
 ATTENDEE_SCHEMA = vol.Schema(
     {
@@ -182,49 +178,40 @@ ATTENDEE_SCHEMA = vol.Schema(
     }
 )
 
-CALENDAR_SERVICE_CREATE_SCHEMA = vol.Schema(
-    {
-        vol.Optional(ATTR_ENTITY_ID): cv.string,
-        vol.Required(ATTR_CALENDAR_ID): cv.string,
-        vol.Required(ATTR_START): cv.datetime,
-        vol.Required(ATTR_END): cv.datetime,
-        vol.Required(ATTR_SUBJECT): cv.string,
-        vol.Optional(ATTR_BODY): cv.string,
-        vol.Optional(ATTR_LOCATION): cv.string,
-        vol.Optional(ATTR_CATEGORIES): [cv.string],
-        vol.Optional(ATTR_SENSITIVITY): cv.enum(EventSensitivity),
-        vol.Optional(ATTR_SHOW_AS): cv.enum(EventShowAs),
-        vol.Optional(ATTR_IS_ALL_DAY): bool,
-        vol.Optional(ATTR_ATTENDEES): [ATTENDEE_SCHEMA],
-    }
-)
-
-CALENDAR_SERVICE_MODIFY_SCHEMA = vol.Schema(
-    {
-        vol.Optional(ATTR_ENTITY_ID): cv.string,
-        vol.Required(ATTR_EVENT_ID): cv.string,
-        vol.Required(ATTR_CALENDAR_ID): cv.string,
-        vol.Optional(ATTR_START): cv.datetime,
-        vol.Optional(ATTR_END): cv.datetime,
-        vol.Required(ATTR_SUBJECT): cv.string,
-        vol.Optional(ATTR_BODY): cv.string,
-        vol.Optional(ATTR_LOCATION): cv.string,
-        vol.Optional(ATTR_CATEGORIES): [cv.string],
-        vol.Optional(ATTR_SENSITIVITY): cv.enum(EventSensitivity),
-        vol.Optional(ATTR_SHOW_AS): cv.enum(EventShowAs),
-        vol.Optional(ATTR_IS_ALL_DAY): bool,
-        vol.Optional(ATTR_ATTENDEES): [ATTENDEE_SCHEMA],
-    }
-)
+CALENDAR_SERVICE_CREATE_SCHEMA = {
+    vol.Required(ATTR_SUBJECT): cv.string,
+    vol.Required(ATTR_START): cv.datetime,
+    vol.Required(ATTR_END): cv.datetime,
+    vol.Optional(ATTR_BODY): cv.string,
+    vol.Optional(ATTR_LOCATION): cv.string,
+    vol.Optional(ATTR_CATEGORIES): [cv.string],
+    vol.Optional(ATTR_SENSITIVITY): cv.enum(EventSensitivity),
+    vol.Optional(ATTR_SHOW_AS): cv.enum(EventShowAs),
+    vol.Optional(ATTR_IS_ALL_DAY): bool,
+    vol.Optional(ATTR_ATTENDEES): [ATTENDEE_SCHEMA],
+}
 
 
-CALENDAR_SERVICE_REMOVE_SCHEMA = vol.Schema(
-    {
-        vol.Optional(ATTR_ENTITY_ID): cv.string,
-        vol.Required(ATTR_EVENT_ID): cv.string,
-        vol.Required(ATTR_CALENDAR_ID): cv.string,
-    }
-)
+CALENDAR_SERVICE_MODIFY_SCHEMA = {
+    vol.Required(ATTR_ENTITY_ID): cv.string,
+    vol.Required(ATTR_EVENT_ID): cv.string,
+    vol.Optional(ATTR_START): cv.datetime,
+    vol.Optional(ATTR_END): cv.datetime,
+    vol.Required(ATTR_SUBJECT): cv.string,
+    vol.Optional(ATTR_BODY): cv.string,
+    vol.Optional(ATTR_LOCATION): cv.string,
+    vol.Optional(ATTR_CATEGORIES): [cv.string],
+    vol.Optional(ATTR_SENSITIVITY): cv.enum(EventSensitivity),
+    vol.Optional(ATTR_SHOW_AS): cv.enum(EventShowAs),
+    vol.Optional(ATTR_IS_ALL_DAY): bool,
+    vol.Optional(ATTR_ATTENDEES): [ATTENDEE_SCHEMA],
+}
+
+
+CALENDAR_SERVICE_REMOVE_SCHEMA = {
+    vol.Required(ATTR_ENTITY_ID): cv.string,
+    vol.Required(ATTR_EVENT_ID): cv.string,
+}
 
 SINGLE_CALSEARCH_CONFIG = vol.Schema(
     {

--- a/custom_components/o365/services.yaml
+++ b/custom_components/o365/services.yaml
@@ -1,19 +1,14 @@
 respond_calendar_event:
   description: "Respond to calendar event/invite"
+  target:
+    device:
+      integration: o365
+    entity:
+      integration: o365
+      domain: calendar
   fields:
-    entity_id:
-      name: Entity
-      description: The calendar's entity_id.
-      required: true
-      example: calendar.calendar
-      selector:
-        entity:
-          domain: calendar
     event_id:
       description: ID for event, can be found as an attribute on you calendar entity's events
-      example: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-    calendar_id:
-      description: (Deprecated) ID for the calendar to create the event in, can be found as an attribute on you calendar entity
       example: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
     response:
       description: "The response to the invite [Accept, Tentative, Decline]"
@@ -27,27 +22,22 @@ respond_calendar_event:
 
 create_calendar_event:
   description: Create new calendar event
+  target:
+    device:
+      integration: o365
+    entity:
+      integration: o365
+      domain: calendar
   fields:
-    entity_id:
-      name: Entity
-      description: The calendar's entity_id.
-      required: true
-      example: calendar.calendar
-      selector:
-        entity:
-          domain: calendar
-    calendar_id:
-      description: (Deprecated) ID for the calendar to create the event in, can be found as an attribute on you calendar entity
-      example: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
     subject:
       description: The subject of the created event
       example: Clean up the garage
     start:
       description: The start time of the event
-      example: "2020-01-01T12:00:00+0000"
+      example: "2023-01-01T12:00:00+0000"
     end:
       description: The end time of the event
-      example: "2020-01-01T12:30:00+0000"
+      example: "2023-01-01T12:30:00+0000"
     body:
       description: The body text for the event (optional)
       example: Remember to also clean out the gutters
@@ -69,31 +59,26 @@ create_calendar_event:
       description: "list of attendees formatted as email: example@example.com type: Required, Optional, or Resource (optional)"
 
 modify_calendar_event:
-  description: Modify existing calendar event, all properties except event_id and calendar_id is optional.
+  description: Modify existing calendar event, all properties except event_id are optional.
+  target:
+    device:
+      integration: o365
+    entity:
+      integration: o365
+      domain: calendar
   fields:
-    entity_id:
-      name: Entity
-      description: The calendar's entity_id.
-      required: true
-      example: calendar.calendar
-      selector:
-        entity:
-          domain: calendar
     event_id:
       description: ID for the event, can be found as an attribute on you calendar entity's events
-      example: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-    calendar_id:
-      description: (Deprecated) ID for the calendar to create the event in, can be found as an attribute on you calendar entity
       example: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
     subject:
       description: The subject of the created event
       example: Clean up the garage
     start:
       description: The start time of the event
-      example: "2020-01-01T12:00:00+0000"
+      example: "2023-01-01T12:00:00+0000"
     end:
       description: The end time of the event
-      example: "2020-01-01T12:30:00+0000"
+      example: "2023-01-01T12:30:00+0000"
     body:
       description: The body text for the event
       example: Remember to also clean out the gutters
@@ -116,18 +101,14 @@ modify_calendar_event:
 
 remove_calendar_event:
   description: Delete calendar event
+  target:
+    device:
+      integration: o365
+    entity:
+      integration: o365
+      domain: calendar
   fields:
-    entity_id:
-      name: Entity
-      description: The calendar's entity_id.
-      required: true
-      example: calendar.calendar
-      selector:
-        entity:
-          domain: calendar
     event_id:
       description: ID for the event, can be found as an attribute on you calendar entity's events
       example: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-    calendar_id:
-      description: (Deprecated) ID for the calendar to create the event in, can be found as an attribute on your calendar entity
-      example: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+

--- a/custom_components/o365/utils.py
+++ b/custom_components/o365/utils.py
@@ -10,11 +10,9 @@ from pathlib import Path
 import yaml
 from bs4 import BeautifulSoup
 from homeassistant.const import CONF_NAME
-from homeassistant.util import dt
 from voluptuous.error import Error as VoluptuousError
 
 from O365.calendar import Attendee  # pylint: disable=no-name-in-module)
-from O365.calendar import EventSensitivity  # pylint: disable=no-name-in-module)
 
 from .const import (
     CONF_ACCOUNT_NAME,
@@ -214,7 +212,7 @@ def get_email_attributes(mail, download_attachments):
     return data
 
 
-def format_event_data(event, calendar_id):
+def format_event_data(event):
     """Format the event data."""
     return {
         "summary": event.subject,
@@ -231,28 +229,39 @@ def format_event_data(event, calendar_id):
             for x in event.attendees._Attendees__attendees  # pylint: disable=protected-access
         ],
         "uid": event.object_id,
-        "calendar_id": calendar_id,
     }
 
 
-def add_call_data_to_event(event, event_data):
+def add_call_data_to_event(
+    event,
+    subject,
+    start,
+    end,
+    body,
+    location,
+    categories,
+    sensitivity,
+    show_as,
+    is_all_day,
+    attendees,
+):
     """Add the call data."""
-    if subject := event_data.get("subject"):
+    if subject:
         event.subject = subject
 
-    if body := event_data.get("body"):
+    if body:
         event.body = body
 
-    if location := event_data.get("location"):
+    if location:
         event.location = location
 
-    if categories := event_data.get("categories"):
+    if categories:
         event.categories = categories
 
-    if show_as := event_data.get("show_as"):
+    if show_as:
         event.show_as = show_as
 
-    if attendees := event_data.get("attendees"):
+    if attendees:
         event.attendees.clear()
         event.attendees.add(
             [
@@ -261,13 +270,12 @@ def add_call_data_to_event(event, event_data):
             ]
         )
 
-    if start := event_data.get("start"):
-        event.start = dt.parse_datetime(start)
+    if start:
+        event.start = start
 
-    if end := event_data.get("end"):
-        event.end = dt.parse_datetime(end)
+    if end:
+        event.end = end
 
-    is_all_day = event_data.get("is_all_day")
     if is_all_day is not None:
         event.is_all_day = is_all_day
         if event.is_all_day:
@@ -278,8 +286,8 @@ def add_call_data_to_event(event, event_data):
                 event.end.year, event.end.month, event.end.day, 0, 0, 0
             )
 
-    if sensitivity := event_data.get("sensitivity"):
-        event.sensitivity = EventSensitivity(sensitivity.lower())
+    if sensitivity:
+        event.sensitivity = sensitivity
     return event
 
 

--- a/docs/sensor.md
+++ b/docs/sensor.md
@@ -1,9 +1,16 @@
 ---
-title: Sensor Layout
+title: Sensors
 nav_order: 6
 ---
 
-# Sensor layout
+# Sensors
+## Calendar Sensor
 The status of the calendar sensor indicates (on/off) whether there is an event on at the current time. The `message`, `all_day`, `start_time`, `end_time`, `location`, `description` and `offset_reached` attributes provide details of the current of next event. A non all-day event is favoured over all_day events.
 
 The `data` attribute provides an array of events for the period defined by the `start_offset` and `end_offset` in `o365_calendars_<account_name>.yaml`. Individual array elements can be accessed using the template notation `states.calendar.calendar_<account_name>.attributes.data[0...n]`.
+
+## Teams Status Sensor
+The Teams Status sensor shows whether the user is online or offline on Teams.
+
+## Teams Chat Sensor
+Shows the latest chat found on MS Teams. Shows the date and time as the status of the sensor, plus content, id and importance of the chat item.

--- a/docs/services.md
+++ b/docs/services.md
@@ -28,7 +28,7 @@ Key | Type | Required | Description
 
 ### Example notify service call
 
-```
+```yaml
 service: notify.o365_email
 data:
   message: The garage door has been open for 10 minutes.
@@ -54,3 +54,24 @@ Remove an event in the specified calendar - All paremeters are shown in the avai
 Respond to an event in the specified calendar - All paremeters are shown in the available parameter list on the Developer Tools/Services tab. Not possible for group calendars.
 ## o365.scan_for_calendars
 Scan for new calendars and add to o365_calendars.yaml - No parameters. Does not scan for group calendars.
+
+### Example create event service call
+
+```yaml
+service: o365.create_calendar_event
+target:
+  entity_id:
+    - calendar.user_primary
+data:
+  subject: Clean up the garage
+  start: 2023-01-01T12:00:00+0000
+  end: 2023-01-01T12:30:00+0000
+  body: Remember to also clean out the gutters
+  location: 1600 Pennsylvania Ave Nw, Washington, DC 20500
+  sensitivity: Normal
+  show_as: Busy
+  attendees:
+    - email: test@example.com
+      type: Required
+
+```


### PR DESCRIPTION
Converts service to being entity services. This allows for:

- the schema to be validated when `Call Service` is clicked by the frontend. 
- provides for better population of the entity_id. 
- removes ability to use calendar_id for service calls - which has been deprecated for about a year
- significantly simplifies service calls by pre-identification of entity information