### PR TITLE
fix: :memo: added possible teams status, from microsoft graph documentation, fix typo on user permissions table

### DIFF
--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -25,7 +25,7 @@ Under "API Permissions" click Add a permission, then Microsoft Graph, then Deleg
    | Calendar | Calendars.ReadWrite   | Y | *Read and write user calendars* |       |
    | Calendar | Calendars.Read.Shared |   | *Read user and shared calendars*  | For shared mailboxes |
    | Calendar | Calendars.ReadWrite.Shared | Y | *Read and write user and shared calendars* | For shared mailboxes |
-   | Calendar | Users.Read            |   | *Sign in and read user profile* |       |
+   | Calendar | User.Read             |   | *Sign in and read user profile* |       |
    | Email    | Mail.Read             |   | *Read access to user mail* |       |
    | Email    | Mail.Send             | Y | *Send mail as a user* |       |
    | Email    | Mail.Read.Shared      |   | *Read user and shared mail* | For shared mailboxes |

--- a/docs/sensor.md
+++ b/docs/sensor.md
@@ -10,7 +10,23 @@ The status of the calendar sensor indicates (on/off) whether there is an event o
 The `data` attribute provides an array of events for the period defined by the `start_offset` and `end_offset` in `o365_calendars_<account_name>.yaml`. Individual array elements can be accessed using the template notation `states.calendar.calendar_<account_name>.attributes.data[0...n]`.
 
 ## Teams Status Sensor
-The Teams Status sensor shows whether the user is online or offline on Teams.
+The Teams Status sensor shows the user's current status on Teams:
+
+* `available`
+* `away`
+* `beRightBack`
+* `busy`
+* `doNotDisturb`
+* `inACall`
+* `inAConferenceCall`
+* `inactive`
+* `inAMeeting`
+* `offline`
+* `offWork`
+* `outOfOffice`
+* `presenceUnknown`
+* `presenting`
+* `urgentInterruptionsOnly`
 
 ## Teams Chat Sensor
 Shows the latest chat found on MS Teams. Shows the date and time as the status of the sensor, plus content, ID and importance of the chat item.


### PR DESCRIPTION
added list of possible teams status to use in an automation, from microsoft graph documentation, fix typo on permissions table (user.read)